### PR TITLE
feature/prepare ingress for kubernetes v1.22

### DIFF
--- a/charts/sealed-secrets-web/templates/NOTES.txt
+++ b/charts/sealed-secrets-web/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if or $.Values.ingress.tls $.Values.ingress.defaultTls}}s{{ end }}://{{ $host.host }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/sealed-secrets-web/templates/ingress.yaml
+++ b/charts/sealed-secrets-web/templates/ingress.yaml
@@ -1,36 +1,64 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "sealed-secrets-web.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-{{ include "sealed-secrets-web.labels" . | indent 4 }}
+    {{- include "sealed-secrets-web.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- else if .Values.ingress.defaultTls }}
+  tls:
+    - {}
+  {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: http
-        {{- end }}
-  {{- end }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/sealed-secrets-web/templates/ingress.yaml
+++ b/charts/sealed-secrets-web/templates/ingress.yaml
@@ -1,16 +1,17 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "sealed-secrets-web.fullname" . -}}
+{{- $cleanSemVersion := trimPrefix "v" .Capabilities.KubeVersion.Version }}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18.0" $cleanSemVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19.0" $cleanSemVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14.0" $cleanSemVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+{{- else }}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
@@ -23,7 +24,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18.0" $cleanSemVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -46,11 +47,11 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if and .pathType (semverCompare ">=1.18.0" $cleanSemVersion) }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              {{- if semverCompare ">=1.19.0" $cleanSemVersion }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/charts/sealed-secrets-web/values.yaml
+++ b/charts/sealed-secrets-web/values.yaml
@@ -27,8 +27,11 @@ ingress:
   annotations: {}
   hosts:
     - host: sealed-secrets-web.local
-      paths: []
-
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  # set this to true and leave tls an empty array to use the default TLS certificate (works at least in openshift)
+  defaultTls: false
   tls: []
 
 resources: {}

--- a/charts/sealed-secrets-web/values.yaml
+++ b/charts/sealed-secrets-web/values.yaml
@@ -24,12 +24,18 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: sealed-secrets-web.local
       paths:
         - path: /
           pathType: ImplementationSpecific
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
   # set this to true and leave tls an empty array to use the default TLS certificate (works at least in openshift)
   defaultTls: false
   tls: []


### PR DESCRIPTION
The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22. 
This PR make ingress object ready for kubernetes versions >= v1.22.

see: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22 for more details.

In addition it is tested on openshift 4.7 and can be used as a drop in replacement for the route feature branch if wanted.