### PR TITLE
flexibility in using Helm chart: args, env, probes & better security and namespaces usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ helm upgrade --install sealed-secrets-web bakito/sealed-secrets-web \
   --set disableLoadSecrets=true
 ```
 
+To render templates locally:
+
+```sh
+cd chart
+helm template . -f values.yaml
+```
+
 You can check helm values available at https://github.com/bakito/sealed-secrets-web/blob/main/chart/values.yaml
 Also, check available application options at https://github.com/bakito/sealed-secrets-web/blob/main/pkg/config/types.go#L14-L22
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v3.0.6
+appVersion: v3.0.7
 description: A web interface for Sealed Secrets by Bitnami.
 home: https://github.com/bakito/sealed-secrets-web
 icon: https://raw.githubusercontent.com/bakito/sealed-secrets-web/master/assets/logo.png
@@ -7,7 +7,7 @@ maintainers:
   - name: bakito
     url: https://github.com/bakito
 name: sealed-secrets-web
-version: 3.0.6
+version: 3.0.7
 #annotations:
 #  artifacthub.io/changes: |
 #    -

--- a/chart/README.md
+++ b/chart/README.md
@@ -17,9 +17,9 @@ helm install sealed-secrets-web bakito/sealed-secrets-web
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | deployment.args | object | `{"defaultArgsEnabled":true}` | Default process arguments are used, while additional can be added too |
-| deployment.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"},"initialDelaySeconds":15,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Liveness Probes |
-| deployment.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":10}` | Readiness Probes |
-| deployment.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":1000,"runAsUser":1000}` | Hardening security |
+| deployment.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"}}` | Liveness Probes |
+| deployment.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"}}` | Readiness Probes |
+| deployment.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":1000,"runAsUser":1001}` | Hardening security |
 | disableLoadSecrets | bool | `false` | If set to true secrets cannot be read from this tool, only seal new ones |
 | fullnameOverride | string | `""` | String to fully override "argo-rollouts.fullname" template |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -27,7 +27,6 @@ helm install sealed-secrets-web bakito/sealed-secrets-web
 | image.tag | string | `nil` | Overrides the image tag (default is the chart appVersion) |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Registry secret names as an array. |
 | includeLocalNamespaceOnly | bool | `false` | If set to true, the application has only the permission to view sealed secrets in the current namespace |
-| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/limit-rpm":"300"}` | Ingress annotations |
 | ingress.className | string | `""` | Ingress class name |
 | ingress.defaultTls | bool | `false` | set this to true and leave tls an empty array to use the default TLS certificate (works at least in openshift) |
 | ingress.enabled | bool | `false` | Enable ingress support |

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,6 +1,6 @@
 # sealed-secrets-web
 
-![Version: 3.0.6](https://img.shields.io/badge/Version-3.0.6-informational?style=flat-square) ![AppVersion: v3.0.6](https://img.shields.io/badge/AppVersion-v3.0.6-informational?style=flat-square)
+![Version: 3.0.7](https://img.shields.io/badge/Version-3.0.7-informational?style=flat-square) ![AppVersion: v3.0.7](https://img.shields.io/badge/AppVersion-v3.0.7-informational?style=flat-square)
 
 A web interface for Sealed Secrets by Bitnami.
 
@@ -16,6 +16,10 @@ helm install sealed-secrets-web bakito/sealed-secrets-web
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
+| deployment.args | object | `{"defaultArgsEnabled":true}` | Default process arguments are used, while additional can be added too |
+| deployment.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"},"initialDelaySeconds":15,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Liveness Probes |
+| deployment.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":10}` | Readiness Probes |
+| deployment.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":1000,"runAsUser":1000}` | Hardening security |
 | disableLoadSecrets | bool | `false` | If set to true secrets cannot be read from this tool, only seal new ones |
 | fullnameOverride | string | `""` | String to fully override "argo-rollouts.fullname" template |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -23,12 +27,11 @@ helm install sealed-secrets-web bakito/sealed-secrets-web
 | image.tag | string | `nil` | Overrides the image tag (default is the chart appVersion) |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry. Registry secret names as an array. |
 | includeLocalNamespaceOnly | bool | `false` | If set to true, the application has only the permission to view sealed secrets in the current namespace |
-| ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/limit-rpm":"300"}` | Ingress annotations |
 | ingress.className | string | `""` | Ingress class name |
 | ingress.defaultTls | bool | `false` | set this to true and leave tls an empty array to use the default TLS certificate (works at least in openshift) |
 | ingress.enabled | bool | `false` | Enable ingress support |
-| ingress.hosts | list | `[]` | Ingress hosts |
-| ingress.tls | list | `[]` | Ingress tls |
+| ingress.hosts | list | `[{"paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress hosts |
 | initialSecretFile | string | `nil` | Define you custom initial secret file |
 | nameOverride | string | `""` | String to partially override "argo-rollouts.fullname" template |
 | nodeSelector | object | `{}` | [Node selector] |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -33,12 +33,10 @@ spec:
           {{- if .Values.deployment.args.defaultArgsEnabled }}
           {{- include "sealed-secrets-web.imageArgs" . | nindent 12 }}
           {{- end }}
-
           {{- if .Values.deployment.args.additionalArgs }}
           {{- toYaml .Values.deployment.args.additionalArgs | nindent 12 }}
           {{- end }}
           {{- end }}
-
           {{- if .Values.deployment.env }}
           env:
           {{- if .Values.deployment.env.SEALEDSECRETSCONTROLLERNAMESPACE }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.deployment.create }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,20 +28,69 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.deployment.args }}
           args:
+          {{- if .Values.deployment.args.defaultArgsEnabled }}
           {{- include "sealed-secrets-web.imageArgs" . | nindent 12 }}
+          {{- end }}
+
+          {{- if .Values.deployment.args.additionalArgs }}
+          {{- toYaml .Values.deployment.args.additionalArgs | nindent 12 }}
+          {{- end }}
+          {{- end }}
+
+          {{- if .Values.deployment.env }}
+          env:
+          {{- if .Values.deployment.env.SEALEDSECRETSCONTROLLERNAMESPACE }}
+          - name: SEALED_SECRETS_CONTROLLER_NAMESPACE
+            value: {{ .Values.deployment.env.SEALEDSECRETSCONTROLLERNAMESPACE }}
+          {{- end }}
+          {{- if .Values.deployment.env.SEALEDSECRETSCONTROLLERNAME }}
+          - name: SEALED_SECRETS_CONTROLLER_NAME
+            value: {{ .Values.deployment.env.SEALEDSECRETSCONTROLLERNAME }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /_health
-              port: http
           readinessProbe:
+            failureThreshold: {{ .Values.deployment.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.deployment.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
             httpGet:
               path: /_health
               port: http
+          livenessProbe:
+            failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.deployment.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+            httpGet:
+              path: /_health
+              port: http
+          {{- if .Values.deployment.securityContext }}
+          securityContext:
+            {{- if .Values.deployment.securityContext.allowPrivilegeEscalation }}
+            allowPrivilegeEscalation: {{ .Values.deployment.securityContext.allowPrivilegeEscalation }}
+            {{- end }}
+            {{- if .Values.deployment.securityContext.capabilitiesDrop }}
+            capabilities:
+              drop: {{- toYaml .Values.deployment.securityContext.capabilitiesDrop | nindent 14 }}
+            {{- end }}
+            {{- if .Values.deployment.securityContext.privileged }}
+            privileged: {{ .Values.deployment.securityContext.privileged }}
+            {{- end }}
+            {{- if .Values.deployment.securityContext.runAsGroup }}
+            runAsGroup: {{ .Values.deployment.securityContext.runAsGroup }}
+            {{- end }}
+            {{- if .Values.deployment.securityContext.runAsUser }}
+            runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
+            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.volumeMounts }}
@@ -67,3 +117,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{ end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.deployment.create }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,55 +38,30 @@ spec:
           {{- end }}
           {{- if .Values.deployment.env }}
           env:
-          {{- if .Values.deployment.env.SEALEDSECRETSCONTROLLERNAMESPACE }}
+          {{- if .Values.deployment.env.sealedSecretsControllerNamespace }}
           - name: SEALED_SECRETS_CONTROLLER_NAMESPACE
-            value: {{ .Values.deployment.env.SEALEDSECRETSCONTROLLERNAMESPACE }}
+            value: {{ .Values.deployment.env.sealedSecretsControllerNamespace }}
           {{- end }}
-          {{- if .Values.deployment.env.SEALEDSECRETSCONTROLLERNAME }}
+          {{- if .Values.deployment.env.sealedSecretsControllerName }}
           - name: SEALED_SECRETS_CONTROLLER_NAME
-            value: {{ .Values.deployment.env.SEALEDSECRETSCONTROLLERNAME }}
+            value: {{ .Values.deployment.env.sealedSecretsControllerName }}
           {{- end }}
           {{- end }}
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- with .Values.deployment.readinessProbe }}
           readinessProbe:
-            failureThreshold: {{ .Values.deployment.readinessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
-            successThreshold: {{ .Values.deployment.readinessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
-            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
-            httpGet:
-              path: /_health
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.livenessProbe }}
           livenessProbe:
-            failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
-            successThreshold: {{ .Values.deployment.livenessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
-            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
-            httpGet:
-              path: /_health
-              port: http
-          {{- if .Values.deployment.securityContext }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.securityContext }}
           securityContext:
-            {{- if .Values.deployment.securityContext.allowPrivilegeEscalation }}
-            allowPrivilegeEscalation: {{ .Values.deployment.securityContext.allowPrivilegeEscalation }}
-            {{- end }}
-            {{- if .Values.deployment.securityContext.capabilitiesDrop }}
-            capabilities:
-              drop: {{- toYaml .Values.deployment.securityContext.capabilitiesDrop | nindent 14 }}
-            {{- end }}
-            {{- if .Values.deployment.securityContext.privileged }}
-            privileged: {{ .Values.deployment.securityContext.privileged }}
-            {{- end }}
-            {{- if .Values.deployment.securityContext.runAsGroup }}
-            runAsGroup: {{ .Values.deployment.securityContext.runAsGroup }}
-            {{- end }}
-            {{- if .Values.deployment.securityContext.runAsUser }}
-            runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -115,4 +89,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-{{ end }}

--- a/chart/templates/service-account.yaml
+++ b/chart/templates/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "sealed-secrets-web.serviceAccountName" . }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "sealed-secrets-web.labels" . | nindent 4 }}
 {{ end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "sealed-secrets-web.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "sealed-secrets-web.labels" . | nindent 4 }}
 spec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,23 +72,27 @@ ingress:
   className: ""
 
   # -- Ingress annotations
-  annotations: { }
-  # nginx.ingress.kubernetes.io/rewrite-target: /$2
-  # nginx.ingress.kubernetes.io/use-regex: "true"
-  # nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+  # annotations:
+  #   nginx.ingress.kubernetes.io/rewrite-target: /$2
+  #   nginx.ingress.kubernetes.io/use-regex: "true"
+  #   nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 
   # -- Ingress hosts
-  hosts: [ ]
-  #- paths:
-  #    - path: /ssw(/|$)(.*)
-  #      pathType: Prefix
+  hosts:
+  - host: example.internal
+    paths:
+    - path: /
+      pathType: Prefix
+
   # -- set this to true and leave tls an empty array to use the default TLS certificate (works at least in openshift)
   defaultTls: false
 
   # -- Ingress tls
-  tls: [ ]
-  #  - hosts: [ my-domain.com ]
-  #    secretName: sealed-secrets-web-tls
+  # tls:
+  # - hosts:
+  #   - example.internal
+  #   - another-example.internal
+  #   secretName: sealed-secrets-web-tls
 
 # -- Resource limits and requests for the pods.
 resources: { }
@@ -99,6 +103,45 @@ resources: { }
 #   cpu: 100m
 #   memory: 128Mi
 
+deployment:
+  # -- Specifies whether deployment should be created
+  create: true
+
+  # -- Readiness Probes
+  readinessProbe:
+    failureThreshold: 3
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 10
+    initialDelaySeconds: 30
+
+  # -- Liveness Probes
+  livenessProbe:
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 10
+    initialDelaySeconds: 15
+
+  # -- Hardening security
+  securityContext:
+    allowPrivilegeEscalation: "false"
+    capabilitiesDrop: ["ALL"]
+    privileged: "false"
+    runAsGroup: 1000
+    runAsUser: 1000
+
+  # -- Default process arguments are used, while additional can be added too
+  args:
+    defaultArgsEnabled: true
+    # additionalArgs:
+    # - --disable-load-secrets
+    # - --format=yaml
+
+  # -- Using environment variables
+  # env:
+  #   SEALEDSECRETSCONTROLLERNAMESPACE: sealed-secrets
+  #   SEALEDSECRETSCONTROLLERNAME: sealed-secrets
 
 # -- [Node selector]
 nodeSelector: { }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,7 +66,7 @@ service:
 
 ingress:
   # -- Enable ingress support
-  enabled: true
+  enabled: false
 
   # -- Ingress class name
   className: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,18 +66,18 @@ service:
 
 ingress:
   # -- Enable ingress support
-  enabled: false
+  enabled: true
 
   # -- Ingress class name
   className: ""
 
   # -- Ingress annotations
-  annotations:
-    # -- Specifies number of requests accepted from a given IP each minute
-    nginx.ingress.kubernetes.io/limit-rpm: "180"
-    # nginx.ingress.kubernetes.io/rewrite-target: /$2
-    # nginx.ingress.kubernetes.io/use-regex: "true"
-    # nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+  # annotations:
+  #   # -- Specifies number of requests accepted from a given IP each minute
+  #   nginx.ingress.kubernetes.io/limit-rpm: "180"
+  #   nginx.ingress.kubernetes.io/rewrite-target: /$2
+  #   nginx.ingress.kubernetes.io/use-regex: "true"
+  #   nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 
   # -- Ingress hosts
   hosts:
@@ -109,21 +109,21 @@ deployment:
   # -- Readiness Probes
   readinessProbe:
     failureThreshold: 3
-    periodSeconds: 5
-    successThreshold: 1
-    timeoutSeconds: 10
-    initialDelaySeconds: 30
+    # periodSeconds: 5
+    # successThreshold: 1
+    # timeoutSeconds: 10
+    # initialDelaySeconds: 30
     httpGet:
       path: /_health
       port: http
 
   # -- Liveness Probes
   livenessProbe:
-    periodSeconds: 10
     failureThreshold: 3
-    successThreshold: 1
-    timeoutSeconds: 10
-    initialDelaySeconds: 15
+    # periodSeconds: 10
+    # successThreshold: 1
+    # timeoutSeconds: 10
+    # initialDelaySeconds: 15
     httpGet:
       path: /_health
       port: http
@@ -136,7 +136,7 @@ deployment:
       - ALL
     privileged: false
     runAsGroup: 1000
-    runAsUser: 1000
+    runAsUser: 1001
 
   # -- Default process arguments are used, while additional can be added too
   args:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,17 +72,19 @@ ingress:
   className: ""
 
   # -- Ingress annotations
-  # annotations:
-  #   nginx.ingress.kubernetes.io/rewrite-target: /$2
-  #   nginx.ingress.kubernetes.io/use-regex: "true"
-  #   nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+  annotations:
+    # -- Specifies number of requests accepted from a given IP each minute
+    nginx.ingress.kubernetes.io/limit-rpm: "180"
+    # nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # nginx.ingress.kubernetes.io/use-regex: "true"
+    # nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 
   # -- Ingress hosts
   hosts:
-  - host: example.internal
-    paths:
+  - paths:
     - path: /
       pathType: Prefix
+    # host: example.internal
 
   # -- set this to true and leave tls an empty array to use the default TLS certificate (works at least in openshift)
   defaultTls: false
@@ -104,9 +106,6 @@ resources: { }
 #   memory: 128Mi
 
 deployment:
-  # -- Specifies whether deployment should be created
-  create: true
-
   # -- Readiness Probes
   readinessProbe:
     failureThreshold: 3
@@ -114,6 +113,9 @@ deployment:
     successThreshold: 1
     timeoutSeconds: 10
     initialDelaySeconds: 30
+    httpGet:
+      path: /_health
+      port: http
 
   # -- Liveness Probes
   livenessProbe:
@@ -122,12 +124,17 @@ deployment:
     successThreshold: 1
     timeoutSeconds: 10
     initialDelaySeconds: 15
+    httpGet:
+      path: /_health
+      port: http
 
   # -- Hardening security
   securityContext:
-    allowPrivilegeEscalation: "false"
-    capabilitiesDrop: ["ALL"]
-    privileged: "false"
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    privileged: false
     runAsGroup: 1000
     runAsUser: 1000
 
@@ -140,8 +147,8 @@ deployment:
 
   # -- Using environment variables
   # env:
-  #   SEALEDSECRETSCONTROLLERNAMESPACE: sealed-secrets
-  #   SEALEDSECRETSCONTROLLERNAME: sealed-secrets
+  #   sealedSecretsControllerNamespace: sealed-secrets
+  #   sealedSecretsControllerName: sealed-secrets
 
 # -- [Node selector]
 nodeSelector: { }


### PR DESCRIPTION
Hi,

I have added more ways to use the chart. Those ways are optional and don't change the way templates are rendered now, except:
this block bellow is added by default on Deployment - it improves security:

```
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            runAsGroup: 1000
            runAsUser: 1000
```

Also, missing parameters for probes are added.

----

Let me know, if PR looks good or needs adjustments to be agreed eg not forcing better security in values.yaml file at `deployment.securityContext`.

I have tested this on cluster.

I would like to add these improvements to be able to use this chart and depend on it. So I hope flexibilities and improvements can help other people too. It would be great to have helm chart released.

Let me know your thoughts and also things I should be aware of.

Thanks