### PR TITLE
Allow user-defined labels to be specified for the ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "sealed-secrets-web.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,6 +84,9 @@ ingress:
   #   nginx.ingress.kubernetes.io/use-regex: "true"
   #   nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 
+  # -- Ingress labels
+  labels: {}
+
   # -- Ingress hosts
   hosts:
     - paths:


### PR DESCRIPTION
e.g.
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: sealed-secrets-web
  namespace: default
  labels:
    app.kubernetes.io/name: sealed-secrets-web
    helm.sh/chart: sealed-secrets-web-3.1.5
    app.kubernetes.io/instance: sealed-secrets-web
    app.kubernetes.io/version: "v3.1.5"
    app.kubernetes.io/managed-by: Helm
    one: two
    three: four
```