### PR TITLE
feat(helm): extraContainer (example for Oauth2 Proxy)

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -30,6 +30,7 @@ helm install my-sealed-secrets-web bakito/sealed-secrets-web --version 3.1.6
 | deployment.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"}}` | Readiness Probes |
 | deployment.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":1000,"runAsUser":1001}` | Hardening security |
 | disableLoadSecrets | bool | `false` | If set to true secrets cannot be read from this tool, only seal new ones |
+| extraContainers | list | `[]` | Additional containers to run in the pod |
 | fullnameOverride | string | `""` | String to fully override "argo-rollouts.fullname" template |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/bakito/sealed-secrets-web"` | Repository to use |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.volumes }}
       volumes:
       {{- with .Values.volumes }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -177,3 +177,21 @@ affinity: {}
 
 # -- Optional labels to apply to all resources
 commonLabels: {}
+
+# -- Additional containers to run in the pod
+extraContainers: []
+# extraContainers:
+# - name: oauth-proxy
+#   image: quay.io/oauth2-proxy/oauth2-proxy:v7.5.1
+#   args:
+#   - --upstream=http://127.0.0.1:80
+#   - --http-address=0.0.0.0:8081
+#   - --metrics-address=0.0.0.0:8082
+#   ports:
+#   - containerPort: 8081
+#     name: oauth-proxy
+#     protocol: TCP
+#   - containerPort: 8082
+#     name: oauth-metrics
+#     protocol: TCP
+#   resources: {}


### PR DESCRIPTION
Added feature to add extra containers to the pod with an example (in comments) for [Oauth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) in the values.yaml file