### PR TITLE
feat(helm): extraPort (used for OauthProxy for example)

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -56,6 +56,7 @@ helm install my-sealed-secrets-web bakito/sealed-secrets-web --version 3.1.7
 | sealedSecrets.serviceName | string | `"sealed-secrets"` | Name of the sealed secrets service |
 | service.annotations | object | `{}` | Service annotations |
 | service.clusterIP | string | `""` | Kubernetes Service clusterIP |
+| service.extraPorts | list | `[]` | Additional ports to add to the service |
 | service.loadBalancerIP | string | `""` | Kubernetes Service loadBalancerIP |
 | service.loadBalancerSourceRanges | list | `[]` | Kubernetes Service loadBalancerSourceRanges |
 | service.nodePort | string | `nil` | Kubernetes Service Nodeport |

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -31,6 +31,9 @@ spec:
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    {{- with .Values.service.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "sealed-secrets-web.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -76,6 +76,14 @@ service:
   loadBalancerSourceRanges: []
   # -- Kubernetes Service Nodeport
   nodePort: null
+  # -- Additional ports to add to the service
+  extraPorts: []
+  # - name: oauth-proxy
+  #   port: 8081
+  #   targetPort: 8081
+  # - name: oauth-metrics
+  #   port: 8082
+  #   targetPort: 8082
 
 ingress:
   # -- Enable ingress support


### PR DESCRIPTION
to use the example with the OauthProxy (see [PR](https://github.com/bakito/sealed-secrets-web/pull/293)) I added the feature to add additional ports to the service in the helm template with an example