### PR TITLE
feat: add regex include and exclude for namespaces

### DIFF
--- a/pkg/handler/secrets.go
+++ b/pkg/handler/secrets.go
@@ -20,24 +20,30 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// BuildClients build the  k82 clients
+// BuildClients builds the Kubernetes clients
+// This function creates two clients: one for standard Kubernetes resources and one for Sealed Secrets
 func BuildClients(
-	clientConfig clientcmd.ClientConfig,
-	disableLoadSecrets bool,
+	clientConfig clientcmd.ClientConfig, // Configuration for the Kubernetes connection
+	disableLoadSecrets bool, // Flag to disable loading secrets
 ) (corev1.CoreV1Interface, ssClient.BitnamiV1alpha1Interface, error) {
+	// If loading secrets is disabled, return empty clients
 	if disableLoadSecrets {
 		return nil, nil, nil
 	}
+
+	// Create client configuration from the provided config
 	conf, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Create standard Kubernetes client for core resources (including Secrets)
 	restClient, err := corev1.NewForConfig(conf)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Create specialized client for Sealed Secrets
 	ssCl, err := ssClient.NewForConfig(conf)
 	if err != nil {
 		return nil, nil, err
@@ -46,42 +52,135 @@ func BuildClients(
 	return restClient, ssCl, nil
 }
 
-// SecretsHandler handles our secrets operations.
+// SecretsHandler manages all operations for secrets
 type SecretsHandler struct {
-	coreClient         corev1.CoreV1Interface
-	ssClient           ssClient.BitnamiV1alpha1Interface
-	disableLoadSecrets bool
-	includeNamespaces  map[string]bool
+	coreClient         corev1.CoreV1Interface            // Client for standard Kubernetes resources
+	ssClient           ssClient.BitnamiV1alpha1Interface // Client for Sealed Secrets
+	disableLoadSecrets bool                              // Flag whether secrets can be loaded
+	includeNamespaces  map[string]bool                   // Map for quick checking if a namespace is included
+	config             *config.Config                    // General configuration
 }
 
-// NewHandler creates a new secret handler.
+// NewHandler creates a new secrets handler
 func NewHandler(
 	coreClient corev1.CoreV1Interface,
 	ssCl ssClient.BitnamiV1alpha1Interface,
 	cfg *config.Config,
 ) *SecretsHandler {
+	// Create a map for quick lookups of included namespaces
 	inMap := make(map[string]bool)
 	for _, n := range cfg.IncludeNamespaces {
 		inMap[n] = true
 	}
+
+	// Create and return the new handler
 	return &SecretsHandler{
 		ssClient:           ssCl,
 		coreClient:         coreClient,
 		disableLoadSecrets: cfg.DisableLoadSecrets,
 		includeNamespaces:  inMap,
+		config:             cfg,
 	}
 }
 
-// List returns a list of all secrets.
+// NamespacesMatch checks if a namespace is allowed according to the filter rules
+func (h *SecretsHandler) NamespacesMatch(namespaces []string) map[string]bool {
+	matchedNamespaces := make(map[string]bool)
+	// If regular expressions should be used for filtering
+	if h.config.UseRegex {
+		// Process inclusion rules with RegEx
+		if len(h.config.IncludeNamespacesRegex) > 0 {
+			for _, r := range h.config.IncludeNamespacesRegex {
+				// Check all namespaces and include those matching the RegEx
+				for _, ns := range namespaces {
+					matched := r.FindString(ns) == ns
+					if matched {
+						matchedNamespaces[ns] = true
+					}
+				}
+			}
+		} else {
+			// If no inclusion rules, use all namespaces
+			for _, ns := range namespaces {
+				matchedNamespaces[ns] = true
+			}
+		}
+
+		// Process exclusion rules with RegEx
+		for _, r := range h.config.ExcludeNamespacesRegex {
+			// Remove namespaces that match the exclusion RegEx
+			for ns, _ := range matchedNamespaces {
+				matched := r.FindString(ns) == ns
+				if matched {
+					// Remove the element from the slice (without preserving order)
+					matchedNamespaces[ns] = false
+				}
+			}
+		}
+	} else {
+		// Direct string comparisons for filtering (without RegEx)
+
+		// Add all explicitly included namespaces
+		for _, ns := range h.config.IncludeNamespaces {
+			matchedNamespaces[ns] = true
+		}
+
+		// Apply exclusion logic
+		if len(h.config.ExcludeNamespaces) > 0 {
+			// If no inclusion rules are defined, use all available namespaces
+			if len(h.config.IncludeNamespaces) < 1 {
+				for _, ns := range namespaces {
+					matchedNamespaces[ns] = true
+				}
+			}
+
+			// Remove namespaces that are in the exclusion list
+			for _, exc := range h.config.ExcludeNamespaces {
+				for ns, _ := range matchedNamespaces {
+					if ns == exc {
+						matchedNamespaces[ns] = false
+					}
+				}
+			}
+		}
+	}
+	return matchedNamespaces
+}
+
+// list returns a list of all secrets that match the filter criteria
 func (h *SecretsHandler) list(ctx context.Context) ([]Secret, error) {
 	var secrets []Secret
-	fmt.Printf("secrets: %#v\n", secrets)
+
+	// If loading secrets is disabled, return an empty list
 	if h.disableLoadSecrets {
 		return secrets, nil
 	}
 
-	if len(h.includeNamespaces) > 0 {
-		for ns := range h.includeNamespaces {
+	// If namespace filters are defined (inclusion or exclusion)
+	if len(h.config.ExcludeNamespaces) > 0 || len(h.config.IncludeNamespaces) > 0 {
+		// Exclusion always takes precedence over inclusion
+		var nsNameList []string
+
+		// If no inclusion rules are defined, gather all available namespaces
+		if len(h.config.IncludeNamespaces) <= 0 || h.config.UseRegex {
+			nsList, err := h.coreClient.Namespaces().List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return nil, err
+			}
+			for _, namespace := range nsList.Items {
+				nsNameList = append(nsNameList, namespace.Name)
+			}
+		} else {
+			nsNameList = h.config.IncludeNamespaces
+		}
+
+		matchedNamespaces := h.NamespacesMatch(nsNameList)
+
+		// Get secrets for all matching namespaces
+		for ns, v := range matchedNamespaces {
+			if !v {
+				continue
+			}
 			list, err := h.listForNamespace(ctx, ns)
 			if err != nil {
 				return nil, err
@@ -89,6 +188,8 @@ func (h *SecretsHandler) list(ctx context.Context) ([]Secret, error) {
 			secrets = append(secrets, list...)
 		}
 	} else {
+		// If no filters are specified, list all secrets in all namespaces
+		// Empty string ("") means "all namespaces"
 		list, err := h.listForNamespace(ctx, "")
 		if err != nil {
 			return nil, err
@@ -96,6 +197,7 @@ func (h *SecretsHandler) list(ctx context.Context) ([]Secret, error) {
 		secrets = append(secrets, list...)
 	}
 
+	// Sort secrets: first by namespace, then by name
 	sort.Slice(secrets, func(i, j int) bool {
 		if secrets[i].Namespace == secrets[j].Namespace {
 			return secrets[i].Name < secrets[j].Name
@@ -106,30 +208,44 @@ func (h *SecretsHandler) list(ctx context.Context) ([]Secret, error) {
 	return secrets, nil
 }
 
+// listForNamespace retrieves all Sealed Secrets in a specific namespace
 func (h *SecretsHandler) listForNamespace(ctx context.Context, ns string) ([]Secret, error) {
 	var secrets []Secret
+
+	// API call to retrieve all SealedSecrets in the specified namespace
+	// Empty string ("") means "all namespaces"
 	ssList, err := h.ssClient.SealedSecrets(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
+
+	// Convert SealedSecrets to the simpler Secret structure
 	for _, item := range ssList.Items {
 		secrets = append(secrets, Secret{Namespace: item.Namespace, Name: item.Name})
 	}
 	return secrets, nil
 }
 
-// GetSecret returns a secret by name in the given namespace.
+// GetSecret returns a single secret by namespace and name
 func (h *SecretsHandler) GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	// If loading secrets is disabled, return null
 	if h.disableLoadSecrets {
 		return nil, nil
 	}
-	if len(h.includeNamespaces) > 0 && !h.includeNamespaces[namespace] {
+
+	// Check if the namespace is allowed according to the filter rules
+	namespaces := h.NamespacesMatch([]string{namespace})
+	if !namespaces[namespace] {
 		return nil, fmt.Errorf("namespace '%s' is not allowed", namespace)
 	}
+
+	// Retrieve the secret from the Kubernetes cluster
 	secret, err := h.coreClient.Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
+
+	// Clean up secret metadata (remove unnecessary fields)
 	secret.TypeMeta = metav1.TypeMeta{
 		APIVersion: "v1",
 		Kind:       "Secret",
@@ -143,54 +259,72 @@ func (h *SecretsHandler) GetSecret(ctx context.Context, namespace, name string) 
 	return secret, nil
 }
 
+// AllSecrets is an HTTP handler that returns a list of all available secrets
 func (h *SecretsHandler) AllSecrets(c *gin.Context) {
+	// If loading secrets is disabled, return an error
 	if h.disableLoadSecrets {
 		c.JSON(http.StatusForbidden, gin.H{"error": "Loading secrets is disabled"})
 		return
 	}
 
+	// Retrieve secrets
 	sec, err := h.list(c)
 	if err != nil {
+		// Log error and return it to the client
 		log.Printf("Error in %s: %v\n", Sanitize(c.Request.URL.Path), err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
+	// Successful response with the list of secrets
 	c.JSON(http.StatusOK, gin.H{"secrets": sec})
 }
 
+// Secret is an HTTP handler that returns a single secret
 func (h *SecretsHandler) Secret(c *gin.Context) {
+	// Determine the response format (JSON or YAML)
 	contentType, outputFormat, done := NegotiateFormat(c)
 	if done {
-		return
+		return // If the format is not supported, an error response was already sent
 	}
 
+	// If loading secrets is disabled, return an error
 	if h.disableLoadSecrets {
 		c.JSON(http.StatusForbidden, gin.H{"error": "Loading secrets is disabled"})
 		return
 	}
 
-	// Load existing secret.
+	// Extract and sanitize parameters from the request
 	namespace := Sanitize(c.Param("namespace"))
 	name := Sanitize(c.Param("name"))
+
+	// Retrieve the secret
 	secret, err := h.GetSecret(c, namespace, name)
 	if err != nil {
+		// Log error and return it to the client
 		log.Printf("Error in %s: %v\n", Sanitize(c.Request.URL.Path), err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
+	// Encode the secret in the desired format
 	encode, err := encodeSecret(secret, outputFormat)
 	if err != nil {
+		// Log encoding error and return it
 		log.Printf("Error in %s: %v\n", Sanitize(c.Request.URL.Path), err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+
+	// Successful response with the encoded secret
 	c.Data(http.StatusOK, contentType, encode)
 }
 
+// encodeSecret encodes a Secret object into the specified format (JSON or YAML)
 func encodeSecret(secret *v1.Secret, outputFormat string) ([]byte, error) {
 	var contentType string
+
+	// Determine content type based on the desired output format
 	switch strings.ToLower(outputFormat) {
 	case "json", "":
 		contentType = runtime.ContentTypeJSON
@@ -200,21 +334,27 @@ func encodeSecret(secret *v1.Secret, outputFormat string) ([]byte, error) {
 		return nil, fmt.Errorf("unsupported output format: %s", outputFormat)
 	}
 
+	// Get serializer for the desired format
 	info, ok := runtime.SerializerInfoForMediaType(scheme.Codecs.SupportedMediaTypes(), contentType)
 	if !ok {
 		return nil, fmt.Errorf("unsupported output format: %s", outputFormat)
 	}
 
+	// Use "pretty" serializer if available, otherwise use standard serializer
 	prettyEncoder := info.PrettySerializer
 	if prettyEncoder == nil {
 		prettyEncoder = info.Serializer
 	}
+
+	// Create encoder for the API version
 	encoder := scheme.Codecs.EncoderForVersion(prettyEncoder, schema.GroupVersion{Group: "", Version: "v1"})
 
+	// Encode and return the secret
 	return runtime.Encode(encoder, secret)
 }
 
+// Secret represents the basic data of a Kubernetes Secret
 type Secret struct {
-	Namespace string `json:"namespace" yaml:"namespace"`
-	Name      string `json:"name"      yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"` // Namespace where the secret is located
+	Name      string `json:"name"      yaml:"name"`      // Name of the secret
 }

--- a/pkg/handler/secrets.go
+++ b/pkg/handler/secrets.go
@@ -24,7 +24,7 @@ import (
 // This function creates two clients: one for standard Kubernetes resources and one for Sealed Secrets
 func BuildClients(
 	clientConfig clientcmd.ClientConfig, // Configuration for the Kubernetes connection
-	disableLoadSecrets bool, // Flag to disable loading secrets
+	disableLoadSecrets bool,             // Flag to disable loading secrets
 ) (corev1.CoreV1Interface, ssClient.BitnamiV1alpha1Interface, error) {
 	// If loading secrets is disabled, return empty clients
 	if disableLoadSecrets {
@@ -234,9 +234,11 @@ func (h *SecretsHandler) GetSecret(ctx context.Context, namespace, name string) 
 	}
 
 	// Check if the namespace is allowed according to the filter rules
-	namespaces := h.NamespacesMatch([]string{namespace})
-	if !namespaces[namespace] {
-		return nil, fmt.Errorf("namespace '%s' is not allowed", namespace)
+	if len(h.config.ExcludeNamespaces) > 0 || len(h.config.IncludeNamespaces) > 0 {
+		namespaces := h.NamespacesMatch([]string{namespace})
+		if !namespaces[namespace] {
+			return nil, fmt.Errorf("namespace '%s' is not allowed", namespace)
+		}
 	}
 
 	// Retrieve the secret from the Kubernetes cluster

--- a/pkg/handler/secrets_test.go
+++ b/pkg/handler/secrets_test.go
@@ -1,0 +1,311 @@
+package handler
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/bakito/sealed-secrets-web/pkg/config"
+	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
+	ssfake "github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned/typed/sealedsecrets/v1alpha1/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+var _ = Describe("SecretsHandler", func() {
+	Context("NamespacesMatch", func() {
+		var handler *SecretsHandler
+
+		BeforeEach(func() {
+			handler = &SecretsHandler{}
+		})
+
+		Context("without regex", func() {
+			BeforeEach(func() {
+				handler.config = &config.Config{UseRegex: false}
+			})
+
+			DescribeTable("include namespaces",
+				func(includeNamespaces []string, inputNamespaces []string, expectedMatches map[string]bool) {
+					handler.config.IncludeNamespaces = includeNamespaces
+					result := handler.NamespacesMatch(inputNamespaces)
+
+					for ns, expected := range expectedMatches {
+						Ω(result).Should(HaveKeyWithValue(ns, expected))
+					}
+				},
+				Entry("includes specified namespaces",
+					[]string{"ns1", "ns2"},
+					[]string{"ns1", "ns2", "ns3"},
+					map[string]bool{"ns1": true, "ns2": true}),
+				Entry("includes only matching namespaces",
+					[]string{"prod", "staging"},
+					[]string{"prod", "dev", "test"},
+					map[string]bool{"prod": true}),
+			)
+
+			DescribeTable("exclude namespaces",
+				func(includeNamespaces, excludeNamespaces []string, inputNamespaces []string, expectedMatches map[string]bool) {
+					handler.config.IncludeNamespaces = includeNamespaces
+					handler.config.ExcludeNamespaces = excludeNamespaces
+					result := handler.NamespacesMatch(inputNamespaces)
+
+					for ns, expected := range expectedMatches {
+						Ω(result).Should(HaveKeyWithValue(ns, expected))
+					}
+				},
+				Entry("excludes from all namespaces when no include list",
+					[]string{},
+					[]string{"ns3"},
+					[]string{"ns1", "ns2", "ns3"},
+					map[string]bool{"ns1": true, "ns2": true, "ns3": false}),
+				Entry("excludes from include list",
+					[]string{"ns1", "ns2", "ns3"},
+					[]string{"ns3"},
+					[]string{"ns1", "ns2", "ns3"},
+					map[string]bool{"ns1": true, "ns2": true, "ns3": false}),
+			)
+
+			It("should return empty map when no filters", func() {
+				result := handler.NamespacesMatch([]string{"ns1", "ns2", "ns3"})
+				Ω(result).Should(BeEmpty())
+			})
+		})
+
+		Context("with regex", func() {
+			BeforeEach(func() {
+				handler.config = &config.Config{UseRegex: true}
+			})
+
+			DescribeTable("include namespaces with regex",
+				func(patterns []string, inputNamespaces []string, expectedMatches map[string]bool) {
+					handler.config.IncludeNamespaces = patterns
+					var regexes []*regexp.Regexp
+					for _, pattern := range patterns {
+						regexes = append(regexes, regexp.MustCompile(pattern))
+					}
+					handler.config.IncludeNamespacesRegex = regexes
+
+					result := handler.NamespacesMatch(inputNamespaces)
+
+					for ns, expected := range expectedMatches {
+						Ω(result).Should(HaveKeyWithValue(ns, expected))
+					}
+				},
+				Entry("matches app namespaces",
+					[]string{"app-.*"},
+					[]string{"app-prod", "app-staging", "kube-system"},
+					map[string]bool{"app-prod": true, "app-staging": true}),
+				Entry("matches multiple patterns",
+					[]string{"test-.*", "prod-.*"},
+					[]string{"test-app", "prod-db", "dev-api"},
+					map[string]bool{"test-app": true, "prod-db": true}),
+			)
+
+			DescribeTable("exclude namespaces with regex",
+				func(includePatterns, excludePatterns []string, inputNamespaces []string, expectedMatches map[string]bool) {
+					handler.config.IncludeNamespaces = includePatterns
+					handler.config.ExcludeNamespaces = excludePatterns
+
+					var includeRegexes []*regexp.Regexp
+					for _, pattern := range includePatterns {
+						includeRegexes = append(includeRegexes, regexp.MustCompile(pattern))
+					}
+					handler.config.IncludeNamespacesRegex = includeRegexes
+
+					var excludeRegexes []*regexp.Regexp
+					for _, pattern := range excludePatterns {
+						excludeRegexes = append(excludeRegexes, regexp.MustCompile(pattern))
+					}
+					handler.config.ExcludeNamespacesRegex = excludeRegexes
+
+					result := handler.NamespacesMatch(inputNamespaces)
+
+					for ns, expected := range expectedMatches {
+						Ω(result).Should(HaveKeyWithValue(ns, expected))
+					}
+				},
+				Entry("excludes kube system namespaces",
+					[]string{},
+					[]string{"kube-.*"},
+					[]string{"default", "kube-system", "kube-public", "app-ns"},
+					map[string]bool{"default": true, "kube-system": false, "kube-public": false, "app-ns": true}),
+				Entry("includes app but excludes test",
+					[]string{"app-.*"},
+					[]string{"app-test.*"},
+					[]string{"app-prod", "app-staging", "app-test-1", "other-ns"},
+					map[string]bool{"app-prod": true, "app-staging": true, "app-test-1": false}),
+			)
+		})
+	})
+
+	Context("list", func() {
+		var (
+			handler      *SecretsHandler
+			fakeClient   *fake.Clientset
+			fakeSSClient *ssfake.FakeBitnamiV1alpha1
+			cfg          *config.Config
+		)
+
+		BeforeEach(func() {
+			fakeClient = fake.NewSimpleClientset()
+			fakeSSClient = &ssfake.FakeBitnamiV1alpha1{
+				Fake: &ktesting.Fake{},
+			}
+			cfg = &config.Config{}
+		})
+
+		JustBeforeEach(func() {
+			handler = NewHandler(fakeClient.CoreV1(), fakeSSClient, cfg)
+		})
+
+		Context("when load secrets is disabled", func() {
+			BeforeEach(func() {
+				cfg.DisableLoadSecrets = true
+			})
+
+			It("should return empty list", func() {
+				result, err := handler.list(context.Background())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(result).Should(BeEmpty())
+			})
+		})
+
+		Context("when no filters are configured", func() {
+			It("should return all sealed secrets", func() {
+				setupSealedSecretsReactor(fakeSSClient, []ssv1alpha1.SealedSecret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ns2"}},
+				})
+
+				result, err := handler.list(context.Background())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(result).Should(ConsistOf(
+					Secret{Name: "secret1", Namespace: "ns1"},
+					Secret{Name: "secret2", Namespace: "ns2"},
+				))
+			})
+		})
+
+		Context("with include namespaces filter", func() {
+			BeforeEach(func() {
+				cfg.IncludeNamespaces = []string{"ns1", "ns3"}
+			})
+
+			It("should return only secrets from included namespaces", func() {
+				setupSealedSecretsReactor(fakeSSClient, []ssv1alpha1.SealedSecret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ns2"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret3", Namespace: "ns3"}},
+				})
+
+				result, err := handler.list(context.Background())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(result).Should(ConsistOf(
+					Secret{Name: "secret1", Namespace: "ns1"},
+					Secret{Name: "secret3", Namespace: "ns3"},
+				))
+			})
+		})
+
+		Context("with exclude namespaces filter", func() {
+			BeforeEach(func() {
+				cfg.ExcludeNamespaces = []string{"ns2"}
+			})
+
+			It("should return secrets from all namespaces except excluded ones", func() {
+				// Setup namespaces in fake client
+				fakeClient = fake.NewClientset(
+					&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+					&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns2"}},
+					&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns3"}},
+				)
+
+				setupSealedSecretsReactor(fakeSSClient, []ssv1alpha1.SealedSecret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ns2"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret3", Namespace: "ns3"}},
+				})
+
+				handler = NewHandler(fakeClient.CoreV1(), fakeSSClient, cfg)
+				result, err := handler.list(context.Background())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(result).Should(ConsistOf(
+					Secret{Name: "secret1", Namespace: "ns1"},
+					Secret{Name: "secret3", Namespace: "ns3"},
+				))
+			})
+		})
+
+		Context("with regex filters", func() {
+			BeforeEach(func() {
+				cfg.UseRegex = true
+				cfg.IncludeNamespaces = []string{"app-.*"}
+				cfg.IncludeNamespacesRegex = []*regexp.Regexp{regexp.MustCompile("app-.*")}
+			})
+
+			It("should return secrets matching regex pattern", func() {
+				// Setup namespaces in fake client
+				fakeClient = fake.NewClientset(
+					&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "app-prod"}},
+					&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+					&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "app-staging"}},
+				)
+
+				setupSealedSecretsReactor(fakeSSClient, []ssv1alpha1.SealedSecret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "app-prod"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "kube-system"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret3", Namespace: "app-staging"}},
+				})
+
+				handler = NewHandler(fakeClient.CoreV1(), fakeSSClient, cfg)
+				result, err := handler.list(context.Background())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(result).Should(ConsistOf(
+					Secret{Name: "secret1", Namespace: "app-prod"},
+					Secret{Name: "secret3", Namespace: "app-staging"},
+				))
+			})
+		})
+
+		Context("sorting", func() {
+			It("should sort results by namespace then by name", func() {
+				setupSealedSecretsReactor(fakeSSClient, []ssv1alpha1.SealedSecret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "z-secret", Namespace: "ns2"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "b-secret", Namespace: "ns1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "a-secret", Namespace: "ns1"}},
+				})
+
+				result, err := handler.list(context.Background())
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(result).Should(Equal([]Secret{
+					{Name: "a-secret", Namespace: "ns1"},
+					{Name: "b-secret", Namespace: "ns1"},
+					{Name: "z-secret", Namespace: "ns2"},
+				}))
+			})
+		})
+	})
+})
+
+func setupSealedSecretsReactor(fakeSSClient *ssfake.FakeBitnamiV1alpha1, sealedSecrets []ssv1alpha1.SealedSecret) {
+	fakeSSClient.Fake.AddReactor("list", "sealedsecrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		listAction := action.(ktesting.ListAction)
+		requestedNamespace := listAction.GetNamespace()
+
+		ssList := &ssv1alpha1.SealedSecretList{}
+		for _, ss := range sealedSecrets {
+			// If namespace is empty string, return all secrets
+			// Otherwise, only return secrets from the requested namespace
+			if requestedNamespace == "" || ss.Namespace == requestedNamespace {
+				ssList.Items = append(ssList.Items, ss)
+			}
+		}
+
+		return true, ssList, nil
+	})
+}


### PR DESCRIPTION
🚀 Feature: Namespace Filtering with Regex Support
This pull request introduces a new feature to sealed-secrets-web that allows users to define included and excluded namespaces, enhancing control over which namespaces are displayed or processed.

🔧 Key Features:
Include/Exclude Namespace Lists: Users can specify namespaces to include or exclude.
Regex Support: Optional regular expressions can be used for flexible pattern matching.
Improved Filtering Logic: Ensures that only relevant namespaces are shown based on user configuration.

📌 Motivation:
This feature provides more granular control over namespace visibility, especially useful in large clusters or multi-tenant environments.

✅ Status:
- [x] Feature implemented
- [x] Unit tests added/updated
- [ ] Add Documentation with examples - is the CLI help enough?