### PR TITLE
fix: decode UTF-8 multi-byte characters correctly in secret editor

### DIFF
--- a/frontend-tests/decodeSecretData.test.js
+++ b/frontend-tests/decodeSecretData.test.js
@@ -29,8 +29,13 @@ function b64(str) {
   return btoa(str)
 }
 
-function makeSecret(dataEntries) {
-  return `apiVersion: v1\nkind: Secret\nmetadata:\n  name: test\n  namespace: default\ntype: Opaque\ndata:\n${Object.entries(dataEntries).map(([k, v]) => `  ${k}: ${b64(v)}`).join('\n')}\n`
+// UTF-8-safe base64 encoding, for values containing non-Latin1 characters
+function b64Utf8(str) {
+  return btoa(String.fromCharCode(...new TextEncoder().encode(str)))
+}
+
+function makeSecret(dataEntries, encoder = b64) {
+  return `apiVersion: v1\nkind: Secret\nmetadata:\n  name: test\n  namespace: default\ntype: Opaque\ndata:\n${Object.entries(dataEntries).map(([k, v]) => `  ${k}: ${encoder(v)}`).join('\n')}\n`
 }
 
 // Convenience wrappers — most tests only care about the decoded content string
@@ -352,6 +357,21 @@ describe('decodeSecretData – nested content with literal \\n sequences', () =>
   it('preserves literal \\r (two chars) inside a multiline block scalar unchanged', () => {
     const val = 'line: "value\\rhere"\nother: data\n'
     const out = decode(makeSecret({ key: val }))
+    expect(YAML.parse(stripComment(out)).stringData.key).toBe(val)
+  })
+})
+
+describe('decodeSecretData – UTF-8 multi-byte characters', () => {
+  it('decodes German umlauts correctly instead of producing mojibake', () => {
+    const secret = `apiVersion: v1\nkind: Secret\nmetadata:\n  name: test\n  namespace: default\ntype: Opaque\ndata:\n  name: ${b64Utf8('müller')}\n`
+    const out = decode(secret)
+    expect(out).toContain('  name: müller')
+    expect(out).not.toContain('mÃ¼ller')
+  })
+
+  it('round-trips a broader set of multi-byte UTF-8 characters (ö, ä, ü, emoji, CJK)', () => {
+    const val = 'Öl Straße naïve 日本語 🚀'
+    const out = decode(makeSecret({ key: val }, b64Utf8))
     expect(YAML.parse(stripComment(out)).stringData.key).toBe(val)
   })
 })

--- a/static/scripts/decode.js
+++ b/static/scripts/decode.js
@@ -22,7 +22,9 @@ function decodeSecretData(content, format) {
     }
     for (const [key, val] of Object.entries(parsed.data)) {
       try {
-        parsed.stringData[key] = val != null ? atob(val) : ''
+        parsed.stringData[key] = val != null
+          ? new TextDecoder().decode(Uint8Array.from(atob(val), c => c.charCodeAt(0)))
+          : ''
       } catch {
         return { content, error: `Invalid base64 in key "${key}"` }
       }


### PR DESCRIPTION
## Problem Statement

<img width="2328" height="1600" alt="screen-capture-_2_" src="https://github.com/user-attachments/assets/ae8f4e84-16fc-4564-bc5c-76b78791b2c2" />


`decodeSecretData` (introduced in PR #363, v3.3.0) automatically converts a loaded secret's `.data` (base64) to `.stringData` (plaintext) so it can be edited. The decoding step used the browser's `atob()` directly:

```js
parsed.stringData[key] = val != null ? atob(val) : ''
```

`atob()` base64-decodes into a "binary string" where each JS character represents a single raw byte — it does not interpret multi-byte UTF-8 sequences. Any secret value containing non-ASCII text (umlauts, accented characters, etc.) was rendered as mojibake in the editor, e.g. `müller` became `mÃ¼ller`, and `café español` became `cafÃ© espaÃ±ol`. This made such values unreadable and, if saved back through the sealing workflow, would have corrupted the original data.

---

## Root Cause

A multi-byte UTF-8 character like `ü` (bytes `0xC3 0xBC`) was decoded by `atob()` into two separate one-byte JS characters (`Ã`, `¼`) instead of being recombined into the single code point `ü`. The backend was not implicated — `pkg/handler/secrets.go` passes through Kubernetes' base64-encoded `Secret.Data` unmodified, correctly encoded from UTF-8 bytes.

---

## Solution

Decode through `TextDecoder` so the raw bytes produced by `atob()` are interpreted as UTF-8 before being assigned as the string value:

```js
parsed.stringData[key] = val != null
  ? new TextDecoder().decode(Uint8Array.from(atob(val), c => c.charCodeAt(0)))
  : ''
```

<img width="2328" height="1600" alt="screen-capture-_3_" src="https://github.com/user-attachments/assets/eef98c8c-89bb-4cf7-a7bd-450ed8fe3003" />


---

## Changes

| Component | Details |
|-----------|---------|
| **Frontend** (`static/scripts/decode.js`) | `decodeSecretData` decodes base64 values via `TextDecoder`/`Uint8Array` instead of bare `atob()`, so multi-byte UTF-8 characters are recombined correctly |
| **Frontend tests** (`frontend-tests/decodeSecretData.test.js`) | Added a UTF-8-safe base64 helper (`b64Utf8`) and two new test cases: German umlauts round-trip correctly (no `mÃ¼ller`-style mojibake), and a broader set of multi-byte characters (umlauts, `ß`, emoji, CJK) round-trip through decode/parse |

---

## Testing

- **Frontend unit tests:** `npm test --prefix frontend-tests` — 45 cases, all passing (43 existing + 2 new)
- **Manual:** Loaded a secret containing `müller` and `café español` via the Secrets UI; verified the editor now shows the original characters instead of garbled output
